### PR TITLE
feat: public api endpoints are now locked before registration starts

### DIFF
--- a/public/__init__.py
+++ b/public/__init__.py
@@ -25,6 +25,10 @@ def create_app(debug=None):
     return app
 
 
-if __name__ == "__main__":
+def main():
     app = create_app()
     app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/public/api.py
+++ b/public/api.py
@@ -19,7 +19,7 @@ from shared.api.db import (
     Player,
 )
 from shared.api.fftt_api import get_player_fftt
-from shared.api.custom_decorators import before_cutoff
+from shared.api.custom_decorators import during_registration, after_registration_start
 import shared.api.api_errors as ae
 
 public_api_bp = Blueprint("public_api", __name__, url_prefix="/api/public")
@@ -30,7 +30,7 @@ p_schema = PlayerSchema()
 
 
 @public_api_bp.route("/categories", methods=["GET"])
-@before_cutoff
+@during_registration
 def api_public_get_categories():
     c_schema.reset(many=True)
     with Session() as session:
@@ -47,7 +47,7 @@ def api_public_get_categories():
 
 
 @public_api_bp.route("/players/<licence_no>", methods=["POST"])
-@before_cutoff
+@during_registration
 def api_public_add_player(licence_no):
     origin = api_public_add_player.__name__
     v_schema = ContactInfoSchema()
@@ -92,7 +92,7 @@ def api_public_add_player(licence_no):
 
 
 @public_api_bp.route("/players/<licence_no>", methods=["GET"])
-@before_cutoff
+@during_registration
 def api_public_get_player(licence_no):
     origin = api_public_get_player.__name__
     with Session() as session:
@@ -123,6 +123,7 @@ def api_public_get_player(licence_no):
 
 
 @public_api_bp.route("/entries/<licence_no>", methods=["GET"])
+@after_registration_start
 def api_public_get_entries(licence_no):
     origin = api_public_get_entries.__name__
     with Session() as session:
@@ -138,7 +139,7 @@ def api_public_get_entries(licence_no):
 
 
 @public_api_bp.route("/entries/<licence_no>", methods=["POST"])
-@before_cutoff
+@during_registration
 def api_public_register_entries(licence_no):
     origin = api_public_register_entries.__name__
     v_schema = CategoryIdsSchema()

--- a/tests/test_public_api/test_public_add_player.py
+++ b/tests/test_public_api/test_public_add_player.py
@@ -100,10 +100,31 @@ incorrect_after = (
     ),
 )
 
+incorrect_before_registration_start = (
+    "555555",
+    {
+        "licenceNo": "555555",
+        "firstName": "Fjhgzg",
+        "lastName": "MHIHOBB",
+        "email": "fdsqjklq@dfjhk.com",
+        "phone": "+33489653754",
+        "gender": "F",
+        "nbPoints": 1500,
+        "club": "USKB",
+    },
+    SampleDates.BEFORE_START,
+    b"",
+    ae.RegistrationCutoffError(
+        origin=origin,
+        error_message=ae.RegistrationMessages.NOT_STARTED,
+    ),
+)
+
 incorrect_add_player = [
     incorrect_player_missing_badly_formatted_data,
     incorrect_player_duplicate,
     incorrect_after,
+    incorrect_before_registration_start,
 ]
 
 

--- a/tests/test_public_api/test_public_get_categories.py
+++ b/tests/test_public_api/test_public_get_categories.py
@@ -307,3 +307,13 @@ class TestAPIGetCategories(BaseTest):
             r = public_client.get("/api/public/categories")
             assert r.status_code == error.status_code, r.json
             assert r.json == error.to_dict(), r.json
+
+    def test_get_before_start(self, public_client, reset_db, populate):
+        error = ae.RegistrationCutoffError(
+            origin="api_public_get_categories",
+            error_message=ae.RegistrationMessages.NOT_STARTED,
+        )
+        with freeze_time(SampleDates.BEFORE_START):
+            r = public_client.get("/api/public/categories")
+            assert r.status_code == error.status_code, r.json
+            assert r.json == error.to_dict(), r.json

--- a/tests/test_public_api/test_public_get_entries.py
+++ b/tests/test_public_api/test_public_get_entries.py
@@ -120,9 +120,19 @@ incorrect_non_existing_player = (
     ),
 )
 
+incorrect_before_registration_start = (
+    "7213526",
+    SampleDates.BEFORE_START,
+    ae.RegistrationCutoffError(
+        origin=origin,
+        error_message=ae.RegistrationMessages.NOT_STARTED,
+    ),
+)
+
 
 incorrect_get_entries = [
     incorrect_non_existing_player,
+    incorrect_before_registration_start,
 ]
 
 
@@ -152,10 +162,6 @@ class TestAPIGetEntries(BaseTest):
         now,
         error,
     ):
-        error = ae.PlayerNotFoundError(
-            origin=origin,
-            licence_no=licence_no,
-        )
         with freeze_time(now):
             r = public_client.get(f"/api/public/entries/{licence_no}")
             assert r.status_code == error.status_code

--- a/tests/test_public_api/test_public_get_player.py
+++ b/tests/test_public_api/test_public_get_player.py
@@ -75,6 +75,16 @@ incorrect_after = (
     ),
 )
 
+incorrect_before_registration_start = (
+    "7513006",
+    SampleDates.BEFORE_START,
+    empty_xml,
+    ae.RegistrationCutoffError(
+        origin=origin,
+        error_message=ae.RegistrationMessages.NOT_STARTED,
+    ),
+)
+
 incorrect_parse_error_missing = (
     "7513006",
     SampleDates.BEFORE_CUTOFF,
@@ -108,6 +118,7 @@ incorrect_get_player = [
     incorrect_already_registered,
     incorrect_after,
     incorrect_parse_error_missing,
+    incorrect_before_registration_start,
 ]
 
 

--- a/tests/test_public_api/test_public_register_entries.py
+++ b/tests/test_public_api/test_public_register_entries.py
@@ -204,6 +204,16 @@ incorrect_registration_after = (
     ),
 )
 
+incorrect_registration_before_registration_start = (
+    "4526124",
+    SampleDates.BEFORE_START,
+    {"categoryIds": ["1"]},
+    ae.RegistrationCutoffError(
+        origin=origin,
+        error_message=ae.RegistrationMessages.NOT_STARTED,
+    ),
+)
+
 incorrect_registration_mandatory_women_only = (
     "1234567",
     SampleDates.BEFORE_CUTOFF,
@@ -233,6 +243,7 @@ incorrect_register_entries = [
     incorrect_registration_empty_categories,
     incorrect_registration_nonexisting_categories,
     incorrect_registration_after,
+    incorrect_registration_before_registration_start,
     incorrect_registration_mandatory_women_only,
     incorrect_registration_max_entries_per_day_man,
 ]


### PR DESCRIPTION
- added @during_registration and @after_registration_start as endpoint decorators
- all public endpoints that were @before_cutoff are now @during_registration
- all other public endpoints are now @after_registration_starts
- added tests for all these locks
- minor refactoring of public/__init__.py to silence pycharm warning